### PR TITLE
[codex] WIP BliZzi Party Tools integration

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -177,7 +177,7 @@
         "BuffRemindersAPI",
         "NaowhQOL_API",
         "MRT_API",
-        "BIT",
+        "BliZziPartyToolsAPI",
         "DetailsAPI",
         "Grid2ProfileAPI",
         "PlaterAPI",

--- a/.luarc.json
+++ b/.luarc.json
@@ -177,6 +177,7 @@
         "BuffRemindersAPI",
         "NaowhQOL_API",
         "MRT_API",
+        "BIT",
         "DetailsAPI",
         "Grid2ProfileAPI",
         "PlaterAPI",

--- a/WagoUI_Creator/modules/generic.lua
+++ b/WagoUI_Creator/modules/generic.lua
@@ -27,6 +27,7 @@ local defaultSortOrder = {
   "Echo Raid Tools",
   "Method Raid Tools",
   "EXBoss",
+  "BliZzi Party Tools",
   "Talent Loadout Ex",
   "OmniCC",
   "NameplateSCT",

--- a/WagoUI_Libraries/LibAddonProfiles/load.xml
+++ b/WagoUI_Libraries/LibAddonProfiles/load.xml
@@ -63,6 +63,7 @@
 	<Script file ="modules\AtrocityEssentials.lua"/>
 	<Script file ="modules\MRT.lua"/>
 	<Script file ="modules\EXBoss.lua"/>
+	<Script file ="modules\BliZzi_Interrupts.lua"/>
   <!-- <Script file ="modules\DandersFramesClickCasting.lua"/> -->
 	<Script file ="finalize.lua"/>
 </Ui>

--- a/WagoUI_Libraries/LibAddonProfiles/modules/BliZzi_Interrupts.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/BliZzi_Interrupts.lua
@@ -1,0 +1,96 @@
+local _, loadingAddonNamespace = ...
+---@type LibAddonProfilesPrivate
+local private = loadingAddonNamespace.GetLibAddonProfilesInternal and loadingAddonNamespace:GetLibAddonProfilesInternal()
+if (not private) then return end
+
+---@type LibAddonProfilesModule
+local m = {
+  moduleName = "BliZzi Party Tools",
+  wagoId = "BKpgeB6E",
+  oldestSupported = "4.1.4",
+  addonNames = { "BliZzi_Interrupts" },
+  conflictingAddons = {},
+  icon = C_AddOns.GetAddOnMetadata("BliZzi_Interrupts", "IconTexture"),
+  slash = "/blizzi",
+  needReloadOnImport = false,
+  needProfileKey = false,
+  preventRename = true,
+  willOverrideProfile = true,
+  nonNativeProfileString = false,
+  needSpecialInterface = false,
+  isLoaded = function(self)
+    local loaded = C_AddOns.IsAddOnLoaded("BliZzi_Interrupts")
+    return loaded
+  end,
+  isUpdated = function(self)
+    return private:GenericVersionCheck(self)
+  end,
+  needsInitialization = function(self)
+    return false
+  end,
+  openConfig = function(self)
+    xpcall(function()
+      BIT.SettingsUI:Toggle()
+    end, geterrorhandler())
+  end,
+  closeConfig = function(self)
+    xpcall(function()
+      BIT.SettingsUI:Toggle()
+    end, geterrorhandler())
+  end,
+  getProfileKeys = function(self)
+    local profileKeys = {
+      ["Global"] = true,
+    }
+    return profileKeys
+  end,
+  getCurrentProfileKey = function(self)
+    return "Global"
+  end,
+  isDuplicate = function(self, profileKey)
+    return true
+  end,
+  setProfile = function(self, profileKey)
+
+  end,
+  testImport = function(self, profileString, profileKey, profileData, rawData, moduleName)
+
+  end,
+  importProfile = function(self, profileString, profileKey, fromIntro)
+    if not profileString then return end
+    xpcall(function()
+      BIT.ImportProfile(profileString)
+    end, geterrorhandler())
+  end,
+  exportProfile = function(self, profileKey)
+    if profileKey and type(profileKey) ~= "string" then return end
+    if profileKey and not self:getProfileKeys()[profileKey] then return end
+    local export
+    xpcall(function()
+      export = BIT.ExportProfile(nil, true)
+    end, geterrorhandler())
+    return export
+  end,
+  areProfileStringsEqual = function(self, profileStringA, profileStringB, tableA, tableB)
+    if not profileStringA or not profileStringB then
+      return false
+    end
+    if profileStringA == profileStringB then
+      return true
+    end
+    local profileDataA, profileDataB
+    xpcall(function()
+      -- TODO: Missing in installed addon source: BIT.DecodeProfileString(profileString)
+      -- implement when fixed in addon source
+    end, geterrorhandler())
+    if not profileDataA or not profileDataB then
+      return false
+    end
+    return private:DeepCompareAsync(profileDataA, profileDataB, {
+      addonVersion = true,
+      formatVersion = true,
+    })
+  end
+}
+
+private.modules[m.moduleName] = m

--- a/WagoUI_Libraries/LibAddonProfiles/modules/BliZzi_Interrupts.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/BliZzi_Interrupts.lua
@@ -7,14 +7,14 @@ if (not private) then return end
 local m = {
   moduleName = "BliZzi Party Tools",
   wagoId = "BKpgeB6E",
-  oldestSupported = "4.1.4",
+  oldestSupported = "4.1.5",
   addonNames = { "BliZzi_Interrupts" },
   conflictingAddons = {},
   icon = C_AddOns.GetAddOnMetadata("BliZzi_Interrupts", "IconTexture"),
   slash = "/blizzi",
   needReloadOnImport = false,
-  needProfileKey = false,
-  preventRename = true,
+  needProfileKey = true,
+  preventRename = false,
   willOverrideProfile = true,
   nonNativeProfileString = false,
   needSpecialInterface = false,
@@ -30,28 +30,38 @@ local m = {
   end,
   openConfig = function(self)
     xpcall(function()
-      BIT.SettingsUI:Toggle()
+      BliZziPartyToolsAPI:OpenConfig()
     end, geterrorhandler())
   end,
   closeConfig = function(self)
     xpcall(function()
-      BIT.SettingsUI:Toggle()
+      BliZziPartyToolsAPI:CloseConfig()
     end, geterrorhandler())
   end,
   getProfileKeys = function(self)
-    local profileKeys = {
-      ["Global"] = true,
-    }
+    local profileKeys = {}
+    xpcall(function()
+      profileKeys = BliZziPartyToolsAPI:GetProfileKeys() or {}
+    end, geterrorhandler())
     return profileKeys
   end,
   getCurrentProfileKey = function(self)
-    return "Global"
+    local profileKey
+    xpcall(function()
+      profileKey = BliZziPartyToolsAPI:GetCurrentProfileKey()
+    end, geterrorhandler())
+    return profileKey
   end,
   isDuplicate = function(self, profileKey)
-    return true
+    if not profileKey then return false end
+    return self:getProfileKeys()[profileKey] ~= nil
   end,
   setProfile = function(self, profileKey)
-
+    if not profileKey then return end
+    if not self:getProfileKeys()[profileKey] then return end
+    xpcall(function()
+      BliZziPartyToolsAPI:SetProfile(profileKey)
+    end, geterrorhandler())
   end,
   testImport = function(self, profileString, profileKey, profileData, rawData, moduleName)
 
@@ -59,15 +69,16 @@ local m = {
   importProfile = function(self, profileString, profileKey, fromIntro)
     if not profileString then return end
     xpcall(function()
-      BIT.ImportProfile(profileString)
+      BliZziPartyToolsAPI:ImportProfile(profileString, profileKey)
     end, geterrorhandler())
   end,
   exportProfile = function(self, profileKey)
-    if profileKey and type(profileKey) ~= "string" then return end
-    if profileKey and not self:getProfileKeys()[profileKey] then return end
+    if not profileKey then return end
+    if type(profileKey) ~= "string" then return end
+    if not self:getProfileKeys()[profileKey] then return end
     local export
     xpcall(function()
-      export = BIT.ExportProfile(nil, true)
+      export = BliZziPartyToolsAPI:ExportProfile(profileKey)
     end, geterrorhandler())
     return export
   end,
@@ -80,16 +91,13 @@ local m = {
     end
     local profileDataA, profileDataB
     xpcall(function()
-      -- TODO: Missing in installed addon source: BIT.DecodeProfileString(profileString)
-      -- implement when fixed in addon source
+      profileDataA = BliZziPartyToolsAPI:DecodeProfileString(profileStringA)
+      profileDataB = BliZziPartyToolsAPI:DecodeProfileString(profileStringB)
     end, geterrorhandler())
     if not profileDataA or not profileDataB then
       return false
     end
-    return private:DeepCompareAsync(profileDataA, profileDataB, {
-      addonVersion = true,
-      formatVersion = true,
-    })
+    return private:DeepCompareAsync(profileDataA, profileDataB)
   end
 }
 


### PR DESCRIPTION
## Summary

Adds a LibAddonProfiles module for BliZzi Party Tools using the public WagoUI profile API added in `BliZzi_Interrupts_v4.1.5`.

## Changes

- Adds `BliZzi Party Tools` module backed by `BliZzi_Interrupts`
- Uses `BliZziPartyToolsAPI` for export, import, profile switching, config, and profile string comparison
- Wires the module into LibAddonProfiles loading and creator sort order
- Adds `BliZziPartyToolsAPI` to Lua diagnostics globals

## Verification

- Confirmed latest Wago stable release is `BliZzi_Interrupts_v4.1.5` with `## X-Wago-ID: BKpgeB6E`
- Confirmed `Profile/WagoAPI.lua` exposes the required profile API surface
- `lua` parse check for the new module and `generic.lua`
- `.luarc.json` parse check

## Notes

Still draft until import/export is validated in-game against the released addon.