### PR TITLE
Fix ElvUI 12.1 profile exports

### DIFF
--- a/WagoUI_Libraries/LibAddonProfiles/modules/ElvUI.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/ElvUI.lua
@@ -2,13 +2,13 @@ local _, loadingAddonNamespace = ...
 ---@type LibAddonProfilesPrivate
 local private = loadingAddonNamespace.GetLibAddonProfilesInternal and loadingAddonNamespace:GetLibAddonProfilesInternal()
 if (not private) then return end
-local EXPORT_PREFIX = "!E1!"
+local EXPORT_PREFIX = "!E2!"
 
 ---@type LibAddonProfilesModule
 local m = {
   moduleName = "ElvUI",
   wagoId = "tukui--2",
-  oldestSupported = "v13.76",
+  oldestSupported = "v15.19",
   addonNames = { "ElvUI", "ElvUI_Libraries", "ElvUI_Options" },
   conflictingAddons = { "Bartender4", "ShadowedUnitFrames", "ShadowedUF_Options", "PitBull4" },
   icon = C_AddOns.GetAddOnMetadata("ElvUI", "IconTexture"),

--- a/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIAuraFilters.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIAuraFilters.lua
@@ -2,12 +2,12 @@ local _, loadingAddonNamespace = ...
 ---@type LibAddonProfilesPrivate
 local private = loadingAddonNamespace.GetLibAddonProfilesInternal and loadingAddonNamespace:GetLibAddonProfilesInternal()
 if (not private) then return end
-local EXPORT_PREFIX = "!E1!"
+local EXPORT_PREFIX = "!E2!"
 
 ---@type LibAddonProfilesModule
 local m = {
   moduleName = "ElvUI Aura Filters",
-  oldestSupported = "v13.76",
+  oldestSupported = "v15.19",
   addonNames = { "ElvUI", "ElvUI_Libraries", "ElvUI_Options" },
   icon = C_AddOns.GetAddOnMetadata("ElvUI", "IconTexture"),
   slash = "/ec",

--- a/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIGlobal.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIGlobal.lua
@@ -2,12 +2,12 @@ local _, loadingAddonNamespace = ...
 ---@type LibAddonProfilesPrivate
 local private = loadingAddonNamespace.GetLibAddonProfilesInternal and loadingAddonNamespace:GetLibAddonProfilesInternal()
 if (not private) then return end
-local EXPORT_PREFIX = "!E1!"
+local EXPORT_PREFIX = "!E2!"
 
 ---@type LibAddonProfilesModule
 local m = {
   moduleName = "ElvUI Account Settings",
-  oldestSupported = "v13.76",
+  oldestSupported = "v15.19",
   addonNames = { "ElvUI", "ElvUI_Libraries", "ElvUI_Options" },
   icon = C_AddOns.GetAddOnMetadata("ElvUI", "IconTexture"),
   slash = "/ec",

--- a/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIPrivate.lua
+++ b/WagoUI_Libraries/LibAddonProfiles/modules/ElvUIPrivate.lua
@@ -2,12 +2,12 @@ local _, loadingAddonNamespace = ...
 ---@type LibAddonProfilesPrivate
 local private = loadingAddonNamespace.GetLibAddonProfilesInternal and loadingAddonNamespace:GetLibAddonProfilesInternal()
 if (not private) then return end
-local EXPORT_PREFIX = "!E1!"
+local EXPORT_PREFIX = "!E2!"
 
 ---@type LibAddonProfilesModule
 local m = {
   moduleName = "ElvUI Private Profile",
-  oldestSupported = "v13.76",
+  oldestSupported = "v15.19",
   addonNames = { "ElvUI", "ElvUI_Libraries", "ElvUI_Options" },
   icon = C_AddOns.GetAddOnMetadata("ElvUI", "IconTexture"),
   slash = "/ec",
@@ -103,18 +103,13 @@ local m = {
     profileData = E:FilterTableFromBlacklist(profileData, D.blacklistedKeys.private)
     if not profileData or (profileData and type(profileData) ~= 'table') then return end
 
-    local profileExport
-    local serialString = D:Serialize(profileData)
+    local serialString = C_EncodingUtil.SerializeCBOR(profileData)
     local success, exportString = pcall(D.CreateProfileExport, D, 'private', profileKey, serialString)
-    if not success then
-      return
-    end
-    local LibDeflate = LibStub:GetLibrary("LibDeflateAsync")
-    local compressedData = LibDeflate:CompressDeflate(exportString, { level = 5 })
-    local printableString = LibDeflate:EncodeForPrint(compressedData)
-    profileExport = printableString and format('%s%s', EXPORT_PREFIX, printableString) or nil
+    if not success then return end
 
-    return profileExport
+    local compressedData = C_EncodingUtil.CompressString(exportString, Enum.CompressionMethod.Deflate or 0, Enum.CompressionLevel.Default or 0)
+    local printableString = C_EncodingUtil.EncodeBase64(compressedData)
+    return printableString and format('%s%s', EXPORT_PREFIX, printableString) or nil
   end,
   areProfileStringsEqual = function(self, profileStringA, profileStringB, tableA, tableB)
     if not profileStringA or not profileStringB then


### PR DESCRIPTION
## Summary

- switch all four ElvUI profile integrations from `!E1!` to `!E2!`
- export ElvUI private profiles with Blizzard CBOR, Deflate, and Base64 APIs
- raise all four ElvUI integration minimum versions to `v15.19`

## Why

ElvUI development commit `0e3685c4` replaced AceSerializer and LibDeflate exports with `C_EncodingUtil`. That removed `Distributor:Serialize`, causing WagoUI private-profile exports to error and changing every ElvUI export prefix to E2.

> [!IMPORTANT]
> Do not merge this PR until ElvUI publishes a new release containing the E2/`C_EncodingUtil` export change. The latest published ElvUI tag is currently `v15.18`; `v15.19` is an expected future version gate, not a published release.

## Impact

WagoUI supports the new ElvUI E2 profile format only. Existing stable ElvUI versions remain below the new minimum version.

